### PR TITLE
chore: add shared standards templates and reusable workflow library

### DIFF
--- a/.github/workflows/reusable-sanity.yml
+++ b/.github/workflows/reusable-sanity.yml
@@ -1,0 +1,18 @@
+name: reusable-sanity
+
+on:
+  workflow_call:
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate baseline docs
+        run: |
+          test -f README.md
+          test -f LICENSE
+          test -f NOTICE
+          test -f CREDITS.md
+          test -f SECURITY.md
+          test -f CONTRIBUTING.md

--- a/.github/workflows/reusable-secret-scan.yml
+++ b/.github/workflows/reusable-secret-scan.yml
@@ -1,0 +1,18 @@
+name: reusable-secret-scan
+
+on:
+  workflow_call:
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install gitleaks (OSS)
+        run: |
+          set -euo pipefail
+          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.24.2/gitleaks_8.24.2_linux_x64.tar.gz -o /tmp/gitleaks.tgz
+          tar -xzf /tmp/gitleaks.tgz -C /tmp
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+      - name: Gitleaks scan
+        run: gitleaks detect --source . --redact --verbose

--- a/docs/templates/CONTRIBUTING.md
+++ b/docs/templates/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+Thanks for contributing.
+
+## Ground rules
+
+- One PR = one focused change.
+- Add tests for behavior changes.
+- Keep secrets out of commits.
+- Prefer small, reviewable diffs.
+
+## Local checks
+
+- Ensure workflows pass on your PR.
+- For `hwvault`, run:
+  - `cargo build --release --bin openclaw-hwvault-resolver`
+  - `cargo test --bin openclaw-hwvault-resolver`
+
+## Security-sensitive changes
+
+For auth, token, policy, or secret-resolution changes:
+
+- document threat assumptions
+- include negative tests (deny-paths)
+- include migration notes if behavior changes

--- a/docs/templates/CREDITS.md
+++ b/docs/templates/CREDITS.md
@@ -1,0 +1,15 @@
+# Credits
+
+## Original author
+
+- Ken (Sylchi)
+
+## Attribution request
+
+If this project helps you, please keep attribution visible in:
+
+- repository forks and mirrors
+- release notes / changelogs
+- product acknowledgements where practical
+
+(Technical/legal requirements are defined by LICENSE and NOTICE.)

--- a/docs/templates/SECURITY.md
+++ b/docs/templates/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+This project is currently in active development. Security fixes are applied to `main` first.
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately via GitHub Security Advisories:
+
+- Go to the repository
+- Security → Advisories → Report a vulnerability
+
+If that is not available, open a private channel with maintainers and do not publish exploit details until patched.
+
+## Scope
+
+In scope:
+
+- authentication / authorization bypasses
+- secret leakage paths
+- remote code execution vectors
+- policy bypasses for delegated secret access
+
+Out of scope:
+
+- social engineering without a technical exploit
+- local admin compromise assumptions

--- a/scripts/sync_repo_standards.sh
+++ b/scripts/sync_repo_standards.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMPLATES="$ROOT/docs/templates"
+BASE="${HWVAULT_REPOS_BASE:-/home/ken/src/releases}"
+
+repos=(hwvault hwvault-extension hwvault-android hwvault-ios)
+for repo in "${repos[@]}"; do
+  target="$BASE/$repo"
+  [[ -d "$target" ]] || { echo "skip missing: $target"; continue; }
+  cp "$TEMPLATES/SECURITY.md" "$target/SECURITY.md"
+  cp "$TEMPLATES/CONTRIBUTING.md" "$target/CONTRIBUTING.md"
+  cp "$TEMPLATES/CREDITS.md" "$target/CREDITS.md"
+  echo "synced standards -> $repo"
+
+done


### PR DESCRIPTION
Adds canonical standards templates (, , ) and reusable GitHub workflows to centralize CI/secret-scan logic for edgerun hwvault repos.